### PR TITLE
[#117704989] Verify commit when tag

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -76,7 +76,7 @@ if [ ! -z "${commit_verification_keys}" ] || [ ! -z "${commit_verification_key_i
     echo "${commit_verification_key_ids}" | \
       xargs --no-run-if-empty -n1 gpg --batch --keyserver $gpg_keyserver --recv-keys
   fi
-  git verify-commit $ref || commit_not_signed
+  git verify-commit $(git rev-list -n 1 $ref) || commit_not_signed
 fi
 
 git lfs fetch

--- a/test/get.sh
+++ b/test/get.sh
@@ -175,6 +175,18 @@ it_can_get_signed_commit() {
   test "$(git -C $dest rev-parse HEAD)" = $ref
 }
 
+it_can_get_signed_commit_via_tag() {
+  local repo=$(init_repo)
+  local commit=$(set -e ; make_signed_commit $repo)
+  local ref=$(make_annotated_tag $repo 'test-0.0.1' 'a message')
+  local dest=$TMPDIR/destination
+
+  get_uri_with_verification_key_and_tag_filter $repo $dest 'test-*' $ref
+
+  test -e $dest/some-file
+  test "$(git -C $dest rev-parse HEAD)" = $commit
+}
+
 it_cant_get_commit_signed_with_unknown_key() {
   local repo=$(init_repo)
   local ref=$(set -e ; make_signed_commit $repo)
@@ -247,3 +259,4 @@ run it_cant_get_commit_signed_with_unknown_key
 run it_cant_get_signed_commit_when_using_keyserver_and_bogus_key
 run it_cant_get_signed_commit_when_using_keyserver_and_unknown_key_id
 run it_can_get_signed_commit_when_using_keyserver
+run it_can_get_signed_commit_via_tag

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -435,6 +435,26 @@ get_uri_with_verification_key() {
   return ${exit_code}
 }
 
+get_uri_with_verification_key_and_tag_filter() {
+  local uri=$1
+  local dest=$2
+  local tag_filter=$3
+  local version=$4
+  jq -n "{
+    source: {
+      uri: $(echo $uri | jq -R .),
+      commit_verification_keys: [\"$(cat ${test_dir}/gpg/public.key)\"],
+      tag_filter: $(echo $tag_filter | jq -R .)
+    },
+    version: {
+      ref: $(echo $version | jq -R .)
+    }
+  }" | ${resource_dir}/in "$dest" | tee /dev/stderr
+  exit_code=$?
+  delete_public_key
+  return ${exit_code}
+}
+
 get_uri_with_invalid_verification_key() {
   jq -n "{
     source: {


### PR DESCRIPTION
# What

When using tag_filter, the check returns a list of tags instead of a list of commits. The chosen tag is passed to in.
This in verifies commits, so we find the commit reference pointing to the tag.
Avoids error: "cannot verify a non-commit object of type tag"

# How to review

* Build the docker image, it will run all the tests
* [This test repository](https://github.com/saliceti/paas-git-resource-test.git) has a tag called `the_tag` pointing to a signed commit. You can test from inside the container.
```
echo '{ "source": { "uri": "https://github.com/saliceti/paas-git-resource-test.git", "commit_verification_key_ids": ["93BD8A652053A480"]}, "version": { "ref": "the_tag"}}' | /opt/resource/in /tmp/paas-git-resource-test
```
It should return the right json and exit with code 0.

# Who can review
Anyone but myself