### PR TITLE
[#118562893] Fix "perl: not found" error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.3
 
-ENV PACKAGES "git openssh-client gnupg jq"
+ENV PACKAGES "git perl openssh-client gnupg jq"
 
 RUN apk add --update $PACKAGES && rm -rf /var/cache/apk/*
 

--- a/test/get.sh
+++ b/test/get.sh
@@ -77,6 +77,14 @@ it_can_get_from_url_only_single_branch() {
   ! git -C $dest rev-parse origin/bogus
 }
 
+it_can_use_submodlues_without_perl_warning() {
+  local repo=$(init_repo_with_submodule | cut -d "," -f1)
+  local dest=$TMPDIR/destination
+
+  output=$(get_uri_with_submodules_all "file://"$repo 1 $dest 2>&1)
+  ! echo "${output}" | grep "perl: not found"
+}
+
 it_honors_the_depth_flag() {
   local repo=$(init_repo)
   local firstCommitRef=$(make_commit $repo)
@@ -249,6 +257,7 @@ run it_can_get_from_url
 run it_can_get_from_url_at_ref
 run it_can_get_from_url_at_branch
 run it_can_get_from_url_only_single_branch
+run it_can_use_submodlues_without_perl_warning
 run it_honors_the_depth_flag
 run it_honors_the_depth_flag_for_submodules
 run it_can_get_and_set_git_config


### PR DESCRIPTION
## Notice

The referenced story isn't in play, but I want to clean this up before we consider either option to get our GPG verification upstream.

## What

This makes our modified container pass the new test that was added in the
preceding commit and upstream as concourse/git-resource#/58.

Failure from before looks like this:

    running it_can_use_submodlues_without_perl_warning...
      Switched to a new branch 'bogus'
      Switched to branch 'master'
      Switched to a new branch 'bogus'
      Switched to branch 'master'
      Cloning into 'repo.eOMCDN'...
      /usr/libexec/git-core/git-submodule: line 1: /usr/bin/perl: not found
      /usr/libexec/git-core/git-submodule: line 1: /usr/bin/perl: not found
    The command '/bin/sh -c /opt/resource-tests/all.sh &&   rm -rf /tmp/*' returned a non-zero code: 1

It increases the size of the resulting image by this much:

    ➜  paas-git-resource git:(fix_submodule_perl) docker images | awk '$1 == "git-resource"'
    git-resource                         fix_submodule_perl   6c682b6e425f        19 minutes ago      88.76 MB
    git-resource                         gds_master           5db676ae6bdc        20 minutes ago      47.9 MB

This isn't necessarily a permanent solution as we may decide to go back to
the busyboxplus image when we submit our GPG changes upstream. See Hector's
description in:

- https://www.pivotaltracker.com/story/show/118562893

## How to review

It's quicker to test this on our "Bootstrap Concourse" than it is "Deployer Concourse".

1. You can apply the following patch to use the container that's been built from this PR:

   ```diff
diff --git a/vagrant/post-deploy.d/30-add-custom-resources.py b/vagrant/post-deploy.d/30-add-custom-resources.py
index 14d6344..740af73 100755
--- a/vagrant/post-deploy.d/30-add-custom-resources.py
+++ b/vagrant/post-deploy.d/30-add-custom-resources.py
@@ -10,7 +10,7 @@ with open(config_file,'r') as f:
     config["resource_types"].extend([
         { "type": "s3-iam", "image": "docker:///governmentpaas/s3-resource" },
         { "type": "semver-iam", "image": "docker:///governmentpaas/semver-resource" },
-        { "type": "git-gpg", "image": "docker:///governmentpaas/git-resource" }
+        { "type": "git-gpg", "image": "docker:///governmentpaas/git-resource#bugfix_submodule_perl_dep" }
     ])

     # Remove any duplicates hashing by type. via http://stackoverflow.com/a/11092590
```
1. Create a "Bootstrap Concourse":

   ```
make dev bootstrap
```
1. Pause the "vpc" job because you don't need it.
1. Run the "init-bucket" job and confirm that the "paas-cf" resource doesn't output the error.

## Who can review

Not @dcarley